### PR TITLE
VDV: Mapping active_periods from ValidityPeriod instead of PublicationWindow

### DIFF
--- a/src/vdv736gtfsrt/adapter/vdv.py
+++ b/src/vdv736gtfsrt/adapter/vdv.py
@@ -65,9 +65,9 @@ class VdvStandardAdapter(BaseAdapter):
     def _convert_active_periods(self, public_transport_situation: PublicTransportSituation) -> list:
         active_periods = list()
 
-        for publication_window in public_transport_situation.PublicationWindow:
-            start_time = sirixml_get_value(publication_window, 'StartTime')
-            end_time = sirixml_get_value(publication_window, 'EndTime')
+        for validity_period in public_transport_situation.ValidityPeriod:
+            start_time = sirixml_get_value(validity_period, 'StartTime')
+            end_time = sirixml_get_value(validity_period, 'EndTime')
 
             active_period = dict()
             if start_time is not None:

--- a/tests/test_adapter_vdv.py
+++ b/tests/test_adapter_vdv.py
@@ -64,7 +64,7 @@ class VdvStandardAdapter_Test(unittest.TestCase):
             self.assertEqual('de', result['alert']['header_text']['translation'][0]['language'])
             self.assertEqual('de', result['alert']['description_text']['translation'][0]['language'])
 
-            self.assertEqual(1728547200, result['alert']['active_period'][0]['start'])
+            self.assertEqual(1728874800, result['alert']['active_period'][0]['start'])
             self.assertEqual(1730077200, result['alert']['active_period'][0]['end'])
 
             self.assertEqual(2, len(result['alert']['informed_entity']))
@@ -82,6 +82,9 @@ class VdvStandardAdapter_Test(unittest.TestCase):
             situation = fromstring(xml_file.read())
 
             result = self.adapter.convert(situation)
+
+            self.assertEqual(1748773800, result['alert']['active_period'][0]['start'])
+            self.assertEqual(1748786400, result['alert']['active_period'][0]['end'])
 
             self.assertEqual(2, len(result['alert']['informed_entity']))
 


### PR DESCRIPTION
The `active_period` elements are not mapped from ValidityPeriod elements instead of PublicationWindow elements because GTFS-RT spec states that the active period is meant to display the time range, when an alert may _really take effect_. Informing passengers in advance is up to the data consuming system, as the service alert is still present in the generated feed.