### PR TITLE
Remove Tabstopps, HTML Tags and double white-spaces

### DIFF
--- a/src/vdv736gtfsrt/adapter/gtfsrt.py
+++ b/src/vdv736gtfsrt/adapter/gtfsrt.py
@@ -1,3 +1,5 @@
+import re
+
 from datetime import datetime
 from io import StringIO
 from html.parser import HTMLParser
@@ -35,7 +37,8 @@ def create_translated_string(languages: List[str], texts: List[str]) -> dict:
     for n in range(0, len(languages)):
         
         translated_text = _strip_tags(texts[n])
-        translated_text = translated_text.replace('\t', '').replace('  ', ' ')
+        translated_text = translated_text.replace('\t', '')
+        translated_text = re.sub(' +', ' ', translated_text)
         
         translated_string['translation'].append({
             'language': languages[n].lower(),

--- a/src/vdv736gtfsrt/adapter/gtfsrt.py
+++ b/src/vdv736gtfsrt/adapter/gtfsrt.py
@@ -9,9 +9,13 @@ def create_translated_string(languages: List[str], texts: List[str]) -> dict:
         raise ValueError('the number of languages must be the same like the number of texts')
     
     for n in range(0, len(languages)):
+        
+        translated_text = texts[n]
+        translated_text = translated_text.replace('\t', '').replace('  ', ' ')
+        
         translated_string['translation'].append({
             'language': languages[n].lower(),
-            'text': texts[n]
+            'text': translated_text
         })
 
     return translated_string

--- a/src/vdv736gtfsrt/adapter/gtfsrt.py
+++ b/src/vdv736gtfsrt/adapter/gtfsrt.py
@@ -1,5 +1,29 @@
 from datetime import datetime
+from io import StringIO
+from html.parser import HTMLParser
 from typing import List
+
+class _HtmlTagStripper(HTMLParser):
+     
+    def __init__(self) -> None:
+         super().__init__()
+         
+         self.reset()
+         self.strict = False
+         self.convert_charrefs = True
+         self.text = StringIO()
+
+    def handle_data(self, d: str) -> None:
+         self.text.write(d)
+
+    def get_stripped_text(self) -> str:
+         return self.text.getvalue()
+    
+def _strip_tags(input: str) -> str:
+     s = _HtmlTagStripper()
+     s.feed(input)
+
+     return s.get_stripped_text()
 
 def create_translated_string(languages: List[str], texts: List[str]) -> dict:
     translated_string = dict()
@@ -10,7 +34,7 @@ def create_translated_string(languages: List[str], texts: List[str]) -> dict:
     
     for n in range(0, len(languages)):
         
-        translated_text = texts[n]
+        translated_text = _strip_tags(texts[n])
         translated_text = translated_text.replace('\t', '').replace('  ', ' ')
         
         translated_string['translation'].append({

--- a/src/vdv736gtfsrt/server.py
+++ b/src/vdv736gtfsrt/server.py
@@ -170,7 +170,7 @@ class GtfsRealtimeServer:
         # send response
         feed_message = self._create_feed_message(objects)
         if format  == 'json':
-            json_result = json.dumps(feed_message, indent=4)
+            json_result = json.dumps(feed_message, indent=4, ensure_ascii=False)
 
             if self._cache is not None:
                 self._cache.set(f"{request.url.path}-{format}", json_result, self._config['caching']['caching_service_alerts_ttl_seconds'])


### PR DESCRIPTION
The `gtfsrt` helper module has been improved to remove tabstopps, unwanted HTML tags and special chars as well as multiple white-spaces at once. The debugging JSON output is also encoded in UTF-8 now.