### PR TITLE
NVBW: Enabled Mapping for Causes and Effects

### DIFF
--- a/src/vdv736gtfsrt/adapter/nvbw/ems.py
+++ b/src/vdv736gtfsrt/adapter/nvbw/ems.py
@@ -4,8 +4,8 @@ from ..gtfsrt import create_url, create_translated_string, iso2unix
 
 class EmsAdapter(VdvStandardAdapter):
 
-    def _convert_alert_cause(self, cause: str) -> str:
-        return 'UNKNOWN_CAUSE'
-
-    def _convert_alert_effect(self, consequences) -> str:
-        return 'UNKNOWN_EFFECT'
+    def _convert_alert_effect(self, consequences, map: dict|None = None) -> str:
+        conditions_map = conditions
+        conditions_map[''] = 'UNKNOWN_EFFECT'
+        
+        return super()._convert_alert_effect(consequences, conditions_map)

--- a/src/vdv736gtfsrt/adapter/nvbw/ems.py
+++ b/src/vdv736gtfsrt/adapter/nvbw/ems.py
@@ -6,6 +6,6 @@ class EmsAdapter(VdvStandardAdapter):
 
     def _convert_alert_effect(self, consequences, map: dict|None = None) -> str:
         conditions_map = conditions
-        conditions_map[''] = 'UNKNOWN_EFFECT'
+        conditions_map['noService'] = 'NO_SERVICE'
         
         return super()._convert_alert_effect(consequences, conditions_map)

--- a/src/vdv736gtfsrt/adapter/vdv.py
+++ b/src/vdv736gtfsrt/adapter/vdv.py
@@ -146,17 +146,22 @@ class VdvStandardAdapter(BaseAdapter):
 
         return informed_entities
     
-    def _convert_alert_cause(self, cause: str) -> str:
-        cause_map = causes
+    def _convert_alert_cause(self, cause: str, map: dict|None = None) -> str:
+        if map is not None and len(map) > 0:
+            cause_map = map
+        else:
+            cause_map = causes
         
         if cause in cause_map:
             return cause_map[cause]
         else:
             return 'UNKNOWN_CAUSE'
 
-    def _convert_alert_effect(self, consequences) -> str:
-        condition_map = conditions
-        condition_map['delayed'] = 'SIGNIFICANT_DELAYS'
+    def _convert_alert_effect(self, consequences, map: dict|None = None) -> str:
+        if map is not None and len(map) > 0:
+            condition_map = map
+        else:
+            condition_map = conditions
 
         # run through all consequences and convert conditions to effects
         effects = list()

--- a/tests/data/xml/SampleSituation4.xml
+++ b/tests/data/xml/SampleSituation4.xml
@@ -39,7 +39,7 @@
     </Affects>
     <Consequences>
     <Consequence>
-        <Condition>diverted</Condition>
+        <Condition>noService</Condition>
         <Severity>normal</Severity>
         <Affects>
         <StopPlaces>

--- a/tests/test_adapter_nvbwems.py
+++ b/tests/test_adapter_nvbwems.py
@@ -27,7 +27,7 @@ class Adapter_NvbwEms_Test(unittest.TestCase):
 
             result = self.adapter.convert(situation)
             
-            self.assertEqual('UNKNOWN_CAUSE', result['alert']['cause'])
+            self.assertEqual('CONSTRUCTION', result['alert']['cause'])
             self.assertEqual('UNKNOWN_EFFECT', result['alert']['effect'])
 
     def test_SampleSituation2(self):

--- a/tests/test_adapter_nvbwems.py
+++ b/tests/test_adapter_nvbwems.py
@@ -38,6 +38,28 @@ class Adapter_NvbwEms_Test(unittest.TestCase):
 
             result = self.adapter.convert(situation)
             
-            self.assertEqual('UNKNOWN_CAUSE', result['alert']['cause'])
+            self.assertEqual('CONSTRUCTION', result['alert']['cause'])
             self.assertEqual('UNKNOWN_EFFECT', result['alert']['effect'])
+
+    def test_SampleSituation3(self):
+
+        xml_filename = os.path.join(os.path.dirname(__file__), 'data/xml/SampleSituation3.xml')
+        with open(xml_filename, 'r') as xml_file:
+            situation = fromstring(xml_file.read())
+
+            result = self.adapter.convert(situation)
+            
+            self.assertEqual('OTHER_CAUSE', result['alert']['cause'])
+            self.assertEqual('DETOUR', result['alert']['effect'])
+
+    def test_SampleSituation4(self):
+
+        xml_filename = os.path.join(os.path.dirname(__file__), 'data/xml/SampleSituation4.xml')
+        with open(xml_filename, 'r') as xml_file:
+            situation = fromstring(xml_file.read())
+
+            result = self.adapter.convert(situation)
+            
+            self.assertEqual('MAINTENANCE', result['alert']['cause'])
+            self.assertEqual('NO_SERVICE', result['alert']['effect'])
             

--- a/tests/test_adapter_vdv.py
+++ b/tests/test_adapter_vdv.py
@@ -59,7 +59,7 @@ class VdvStandardAdapter_Test(unittest.TestCase):
             self.assertEqual('https://yourdomain.com/alerts/de/18acba15-9669-58af-91f1-7a0a3a9c3b98', result['alert']['url']['translation'][0]['text'])
             
             self.assertEqual('CONSTRUCTION', result['alert']['cause'])
-            self.assertEqual('SIGNIFICANT_DELAYS', result['alert']['effect'])
+            self.assertEqual('UNKNOWN_EFFECT', result['alert']['effect'])
 
             self.assertEqual('de', result['alert']['header_text']['translation'][0]['language'])
             self.assertEqual('de', result['alert']['description_text']['translation'][0]['language'])


### PR DESCRIPTION
Mapping for Causes and Effects of service alerts has been re-enabled for the NVBW.EMS adapter again. Also, the customer defined consequence condition `noService` has been mapped to `NO_SERVICE`