### PR TITLE
Fix/Improvements for MQTT-Connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ By default, vdv736gtfsrt uses the more complexe publish/subscribe pattern to act
 Instead of running a GTFS-RT server, you can also run a MQTT publisher. This makes the system fully realtime capable. To run a MQTT publisher, use the command
 
 ```bash
-python -m vdv736gtfsrt mqtt ./config/your-config.yaml -m mqtt://{username}:{password}@{domain}/here/is/your/topic/for/alert/[alertId]
+python -m vdv736gtfsrt mqtt ./config/your-config.yaml -m mqtt://{username}:{password}@{domain}/here/is/your/topic/for/alert/[alertId] -c yourClientId
 ```
 
 or alternatively docker
@@ -71,10 +71,10 @@ docker run
    -v /host/var/log/vdv736gtfsrt/xml:/app/datalog
    -p 9091:9091
    sebastianknopf/vdv736gtfsrt:latest
-   mqtt -m mqtt://{username}:{password}@{domain}/here/is/your/topic/for/alert/[alertId]
+   mqtt -m mqtt://{username}:{password}@{domain}/here/is/your/topic/for/alert/[alertId] -c yourClientID
 ```
 
-Replace `{username}`, `{password}`, `{domain}` by your values. The key `[alertId]` is replaced with the entity ID.
+Replace `{username}`, `{password}`, `{domain}` by your values. The key `[alertId]` is replaced with the entity ID. The parameter `-c` / `--client` is optional to specify a certain client ID at the MQTT broker. Default is `vdv736gtfsrt`.
 
 ### Using Data Logs
 By setting the configuratiion key `app.datalog_enabled` all requests and responses are logged to the directory `./datalog` as raw XML for debugging purposes. When running in Docker, you need to mount a directory on your host to `/app/datalog` to access the XML logs.

--- a/src/vdv736gtfsrt/__main__.py
+++ b/src/vdv736gtfsrt/__main__.py
@@ -32,7 +32,8 @@ def server(config, host, port):
 @cli.command()
 @click.argument('config', default='/app/config/config.yaml')
 @click.option('--mqtt', '-m', help='MQTT connection and topic URI')
-def mqtt(config, mqtt):
+@click.option('--client', '-c', default='vdv736gtfsrt', help='Client-ID for connecting to the MQTT broker')
+def mqtt(config, mqtt, client):
 
     mqtt_uri = urlparse(mqtt)
     mqtt_params = mqtt_uri.netloc.split('@')
@@ -45,7 +46,7 @@ def mqtt(config, mqtt):
         mqtt_username, mqtt_password = mqtt_params[0].split(':')
         mqtt_host, mqtt_port = mqtt_params[1].split(':')
 
-    publisher = GtfsRealtimePublisher(config, mqtt_host, mqtt_port, mqtt_username, mqtt_password, mqtt_topic, 300)
+    publisher = GtfsRealtimePublisher(config, mqtt_host, mqtt_port, mqtt_username, mqtt_password, mqtt_topic, client, 300)
     publisher.run()
 
 

--- a/src/vdv736gtfsrt/mqtt.py
+++ b/src/vdv736gtfsrt/mqtt.py
@@ -91,10 +91,11 @@ class GtfsRealtimePublisher:
         if username is not None and password is not None:
             self._mqtt.username_pw_set(username=username, password=password)
 
-        self._mqtt.on_connect = self._mqtt_on_connect
-        self._mqtt.on_disconnect = self._mqtt_on_disconnect
+        #self._mqtt.on_connect = self._mqtt_on_connect
+        #self._mqtt.on_disconnect = self._mqtt_on_disconnect
 
         self._mqtt.connect(self._mqtt_host, self._mqtt_port)
+        self._mqtt.loop_start()
 
     def run(self) -> None:
         
@@ -119,6 +120,7 @@ class GtfsRealtimePublisher:
 
                 self._subscriber_status_timer.stop()
 
+                # we don't want a re-connection here, so stop the event loop before disconnection
                 self._mqtt.loop_stop()
                 self._mqtt.disconnect()
 
@@ -139,7 +141,8 @@ class GtfsRealtimePublisher:
                     pass
 
                 self._data_update_timer.stop()
-
+                
+                # we don't want a re-connection here, so stop the event loop before disconnection
                 self._mqtt.loop_stop()
                 self._mqtt.disconnect()
 

--- a/src/vdv736gtfsrt/mqtt.py
+++ b/src/vdv736gtfsrt/mqtt.py
@@ -21,7 +21,7 @@ from vdv736.delivery import SiriDelivery
 
 class GtfsRealtimePublisher:
 
-    def __init__(self, config_filename: str, host: str, port: str, username: str, password: str, topic: str, client: str, expiration: int) -> None:
+    def __init__(self, config_filename: str, host: str, port: str, username: str, password: str, topic: str, client_id: str, expiration: int) -> None:
         self._expiration: int = expiration
 
         self._last_processed_index: dict = dict()
@@ -84,7 +84,7 @@ class GtfsRealtimePublisher:
         self._mqtt_host: str = host
         self._mqtt_port: int = int(port)
         
-        self._mqtt = client.Client(client.CallbackAPIVersion.VERSION2, protocol=client.MQTTv5, client_id=client)
+        self._mqtt = client.Client(client.CallbackAPIVersion.VERSION2, protocol=client.MQTTv5, client_id=client_id)
 
         if username is not None and password is not None:
             self._mqtt.username_pw_set(username=username, password=password)

--- a/src/vdv736gtfsrt/mqtt.py
+++ b/src/vdv736gtfsrt/mqtt.py
@@ -86,7 +86,7 @@ class GtfsRealtimePublisher:
         self._mqtt_reconnect_attempts: int = 0
         self._mqtt_connection_active: bool = False
         
-        self._mqtt = client.Client(client.CallbackAPIVersion.VERSION2, protocol=client.MQTTv5)
+        self._mqtt = client.Client(client.CallbackAPIVersion.VERSION2, protocol=client.MQTTv5, client_id='vdv736gtfsrt')
 
         if username is not None and password is not None:
             self._mqtt.username_pw_set(username=username, password=password)

--- a/src/vdv736gtfsrt/mqtt.py
+++ b/src/vdv736gtfsrt/mqtt.py
@@ -29,7 +29,7 @@ class GtfsRealtimePublisher:
         self._run: bool = True
         
         # create internal logger instance
-        logging.basicConfig(level=logging.INFO, format="%(levelname)s:\t %(message)s")
+        logging.basicConfig(format="[%(levelname)s] %(asctime)s %(message)s", level=logging.INFO)
 
         self._logger = logging.getLogger()
 


### PR DESCRIPTION
This PR brings up following fixes and improvements:

- Fix: The MQTT client has been fixed to use `loop_start()` for automatic re-connection. 
- By using the option `-c` you can specify a client ID when connecting to the MQTT broker. This is important, when a MQTT broker uses the client ID for authentication purposes.
- The logs of the MQTT output have been improved to also show a timestamp.